### PR TITLE
fix Version fields type to uint64.

### DIFF
--- a/models/read_object.go
+++ b/models/read_object.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"github.com/tidwall/gjson"
 )
 
@@ -85,7 +86,7 @@ type SuiObjectResponseError struct {
 	Code     string `json:"code"`
 	Error    string `json:"error"`
 	ObjectId string `json:"object_id"`
-	Version  int    `json:"version"`
+	Version  uint64 `json:"version"`
 	Digest   string `json:"digest"`
 }
 
@@ -97,13 +98,13 @@ type ObjectOwner struct {
 }
 
 type ObjectShare struct {
-	InitialSharedVersion int `json:"initial_shared_version"`
+	InitialSharedVersion uint64 `json:"initial_shared_version"`
 }
 
 type SuiRawMoveObject struct {
 	Type              string `json:"type"`
 	HasPublicTransfer bool   `json:"hasPublicTransfer"`
-	Version           int    `json:"version"`
+	Version           uint64 `json:"version"`
 	BcsBytes          string `json:"bcsBytes"`
 }
 
@@ -195,7 +196,7 @@ type DynamicFieldInfo struct {
 	Type       string           `json:"type"`
 	ObjectType string           `json:"objectType"`
 	ObjectId   string           `json:"objectId"`
-	Version    int              `json:"version"`
+	Version    uint64           `json:"version"`
 	Digest     string           `json:"digest"`
 }
 

--- a/models/read_transaction.go
+++ b/models/read_transaction.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"github.com/tidwall/gjson"
 )
 
@@ -82,7 +83,7 @@ type SuiTransactionBlock struct {
 
 type SuiObjectRef struct {
 	ObjectId string `json:"objectId"`
-	Version  int    `json:"version"`
+	Version  uint64 `json:"version"`
 	Digest   string `json:"digest"`
 }
 
@@ -97,7 +98,7 @@ type SuiGasData struct {
 type SuiObjectChangePublished struct {
 	Type      string   `json:"type"`
 	PackageId string   `json:"packageId"`
-	Version   int      `json:"version"`
+	Version   uint64   `json:"version"`
 	Digest    string   `json:"digest"`
 	Modules   []string `json:"modules"`
 }
@@ -108,7 +109,7 @@ type SuiObjectChangeTransferred struct {
 	Recipient  ObjectOwner `json:"recipient"`
 	ObjectType string      `json:"objectType"`
 	ObjectId   string      `json:"objectId"`
-	Version    int         `json:"version"`
+	Version    uint64      `json:"version"`
 	Digest     string      `json:"digest"`
 }
 
@@ -118,8 +119,8 @@ type SuiObjectChangeMutated struct {
 	Owner           ObjectOwner `json:"owner"`
 	ObjectType      string      `json:"objectType"`
 	ObjectId        string      `json:"objectId"`
-	Version         int         `json:"version"`
-	PreviousVersion int         `json:"previousVersion"`
+	Version         uint64      `json:"version"`
+	PreviousVersion uint64      `json:"previousVersion"`
 	Digest          string      `json:"digest"`
 }
 
@@ -128,7 +129,7 @@ type SuiObjectChangeDeleted struct {
 	Sender     string `json:"sender"`
 	ObjectType string `json:"objectType"`
 	ObjectId   string `json:"objectId"`
-	Version    int    `json:"version"`
+	Version    uint64 `json:"version"`
 }
 
 type SuiObjectChangeWrapped struct {
@@ -136,7 +137,7 @@ type SuiObjectChangeWrapped struct {
 	Sender     string `json:"sender"`
 	ObjectType string `json:"objectType"`
 	ObjectId   string `json:"objectId"`
-	Version    int    `json:"version"`
+	Version    uint64 `json:"version"`
 }
 
 type SuiObjectChangeCreated struct {
@@ -145,7 +146,7 @@ type SuiObjectChangeCreated struct {
 	Owner      ObjectOwner `json:"owner"`
 	ObjectType string      `json:"objectType"`
 	ObjectId   string      `json:"objectId"`
-	Version    int         `json:"version"`
+	Version    uint64      `json:"version"`
 	Digest     string      `json:"digest"`
 }
 

--- a/models/signature.go
+++ b/models/signature.go
@@ -21,7 +21,7 @@ type Digest = Base64Data
 type ObjectRef struct {
 	Digest   string   `json:"digest"`
 	ObjectId ObjectId `json:"objectId"`
-	Version  int64    `json:"version"`
+	Version  uint64   `json:"version"`
 }
 
 type SigScheme string


### PR DESCRIPTION
According to the [docs](https://docs.sui.io/concepts/object-model#object-metadata), `Version` fields are of type `uint64` (8-byte unsigned integer).
Under models there are many Version fields that are configured wrongly as `int64` or `int`, modified them all to `uint64`.
For new checkpoints (e.g., 65350700), unmarshaling into `SuiTransactionBlockResponse` fails (`json: cannot unmarshal number 9223372036854775809 into Go struct field SuiObjectRef.effects.sharedObjects.version of type int`).

