### PR TITLE
fix: update faucet endpoint to latest

### DIFF
--- a/constant/rpc.go
+++ b/constant/rpc.go
@@ -11,9 +11,9 @@ const (
 	WssSuiTestnetEndpoint = "wss://fullnode.testnet.sui.io"
 	WssSuiMainnetEndpoint = "wss://fullnode.mainnet.sui.io"
 
-	FaucetTestnetEndpoint  = "https://faucet.testnet.sui.io/gas"
-	FaucetDevnetEndpoint   = "https://faucet.devnet.sui.io"
-	FaucetLocalnetEndpoint = "http://127.0.0.1:9123"
+	FaucetTestnetEndpoint  = "https://faucet.testnet.sui.io/v1/gas"
+	FaucetDevnetEndpoint   = "https://faucet.devnet.sui.io/v1/gas"
+	FaucetLocalnetEndpoint = "http://127.0.0.1:9123/gas"
 )
 
 const (


### PR DESCRIPTION
Based on the [Request test tokens through cURL - sui doc](https://docs.sui.io/guides/developer/getting-started/get-coins#request-test-tokens-through-curl), update faucet endpoints to latest.

Using the old endpoints get error:
```shell
faucetHost: https://faucet.testnet.sui.io/gas
Request faucet failed, statusCode: 404, err:
```