### PR TITLE
fix: add check for object in `GetInputObjectIndex`

### DIFF
--- a/transaction/transaction_data.go
+++ b/transaction/transaction_data.go
@@ -55,6 +55,10 @@ func (td *TransactionDataV1) GetInputObjectIndex(address models.SuiAddress) *uin
 	}
 
 	for i, input := range td.Kind.ProgrammableTransaction.Inputs {
+		if input.Object == nil {
+			continue
+		}
+
 		if input.Object.ImmOrOwnedObject != nil {
 			objectId := input.Object.ImmOrOwnedObject.ObjectId
 			if objectId.IsEqual(*addressBytes) {


### PR DESCRIPTION
Check whether `input.Object` is nil first to avoid panic