### PR TITLE
Change modules to byte[][] type

### DIFF
--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -142,16 +142,7 @@ func (tx *Transaction) MergeCoins(destination Argument, sources []Argument) Argu
 	}))
 }
 
-func (tx *Transaction) Publish(modules []models.SuiAddress, dependencies []models.SuiAddress) Argument {
-	moduleAddress := make([]models.SuiAddressBytes, len(modules))
-	for i, module := range modules {
-		v, err := ConvertSuiAddressStringToBytes(module)
-		if err != nil {
-			panic(err)
-		}
-		moduleAddress[i] = *v
-	}
-
+func (tx *Transaction) Publish(modules [][]byte, dependencies []models.SuiAddress) Argument {
 	dependenciesAddress := make([]models.SuiAddressBytes, len(dependencies))
 	for i, dependency := range dependencies {
 		v, err := ConvertSuiAddressStringToBytes(dependency)
@@ -162,26 +153,17 @@ func (tx *Transaction) Publish(modules []models.SuiAddress, dependencies []model
 	}
 
 	return tx.Add(publish(Publish{
-		Modules:      moduleAddress,
+		Modules:      modules,
 		Dependencies: dependenciesAddress,
 	}))
 }
 
 func (tx *Transaction) Upgrade(
-	modules []models.SuiAddress,
+	modules [][]byte,
 	dependencies []models.SuiAddress,
 	packageId models.SuiAddress,
 	ticket Argument,
 ) Argument {
-	moduleAddress := make([]models.SuiAddressBytes, len(modules))
-	for i, module := range modules {
-		v, err := ConvertSuiAddressStringToBytes(module)
-		if err != nil {
-			panic(err)
-		}
-		moduleAddress[i] = *v
-	}
-
 	dependenciesAddress := make([]models.SuiAddressBytes, len(dependencies))
 	for i, dependency := range dependencies {
 		v, err := ConvertSuiAddressStringToBytes(dependency)
@@ -197,7 +179,7 @@ func (tx *Transaction) Upgrade(
 	}
 
 	return tx.Add(upgrade(Upgrade{
-		Modules:      moduleAddress,
+		Modules:      modules,
 		Dependencies: dependenciesAddress,
 		Package:      *packageIdBytes,
 		Ticket:       &ticket,

--- a/transaction/transaction_data.go
+++ b/transaction/transaction_data.go
@@ -228,7 +228,7 @@ type MergeCoins struct {
 }
 
 type Publish struct {
-	Modules      []models.SuiAddressBytes
+	Modules      [][]byte
 	Dependencies []models.SuiAddressBytes
 }
 
@@ -238,7 +238,7 @@ type MakeMoveVec struct {
 }
 
 type Upgrade struct {
-	Modules      []models.SuiAddressBytes
+	Modules      [][]byte
 	Dependencies []models.SuiAddressBytes
 	Package      models.SuiAddressBytes
 	Ticket       *Argument


### PR DESCRIPTION
## PublishUpgrade Incorrectly Parses Base64 Module Strings as Addresses

The Sui Go SDK's `Publish/Upgrade` method in the transaction package incorrectly attempts to parse base64-encoded module strings as Sui addresses, causing `invalid address format` errors when performing package upgrades.

## Bug Description

When calling `ptb.Upgrade(modules, dependencies, packageId, upgradeTicket)`, the SDK treats the `modules` parameter (which should be Move bytecode `byte[][]`) as Sui addresses and attempts to parse them using `ConvertSuiAddressStringToBytes()`.

Reference: https://github.com/block-vision/sui-go-sdk/blob/main/transaction/transaction.go#L170-L183

```
func (tx *Transaction) Upgrade(
	modules []models.SuiAddress,
	dependencies []models.SuiAddress,
	packageId models.SuiAddress,
	ticket Argument,
) Argument {
	moduleAddress := make([]models.SuiAddressBytes, len(modules))
	for i, module := range modules {
		v, err := ConvertSuiAddressStringToBytes(module)
		if err != nil {
			panic(err)
		}
		moduleAddress[i] = *v
	}
```

This addresses issue https://github.com/block-vision/sui-go-sdk/issues/68