### PR TITLE
fix: Fix BCS encoding for [N]byte arrays to remove unintended length prefix

### DIFF
--- a/mystenbcs/encode.go
+++ b/mystenbcs/encode.go
@@ -103,10 +103,6 @@ func (e *Encoder) encode(v reflect.Value) error {
 		return e.encodeSlice(v)
 
 	case reflect.Array: // encode array
-		// check if the element is [n]byte
-		if byteSlice := fixedByteArrayToSlice(v); byteSlice != nil {
-			return e.encodeByteSlice(byteSlice)
-		}
 		return e.encodeArray(v)
 
 	case reflect.String:


### PR DESCRIPTION
Fix BCS encoding for [N]byte arrays to remove unintended length prefix

